### PR TITLE
a11y: lang attributes

### DIFF
--- a/en_index.html
+++ b/en_index.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Peaceful Student Encampment of the University of Wrocław</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Resistance is the deepest form of love</q></p>
@@ -3160,7 +3160,7 @@
         <span lang="pl">Wrocław</span>
       </address>
       <aside>
-        <p><span lang="ara">فلسطين الحرة</span></p>
+        <p><span lang="ar-apc" dir="rtl">فلسطين الحرة</span></p>
       </aside>
     </footer>
   </body>

--- a/en_index.html
+++ b/en_index.html
@@ -150,7 +150,7 @@
                 <li>
                   In the field of implementing an effective combination of
                   medications to improve therapy against
-                  <i lang="lat">Klebsiella pneumoniae</i> – the bacteria causing
+                  <i lang="la">Klebsiella pneumoniae</i> – the bacteria causing
                   pneumonia.
                 </li>
                 <li>Cooperation in the exchange of students and staff.</li>
@@ -171,7 +171,7 @@
               <li>
                 In the field of implementing an effective combination of
                 medications to improve therapy against
-                <i lang="lat">Klebsiella pneumoniae</i> – the bacteria causing
+                <i lang="la">Klebsiella pneumoniae</i> – the bacteria causing
                 pneumonia.
                 <ul>
                   <li>Project conducted under the KLEOPATRA project.</li>
@@ -1664,7 +1664,7 @@
                 The Hebrew University of Jerusalem in Israel:
                 <br />- In the field of implementing an effective combination of
                 medications to improve therapy against
-                <i lang="lat">Klebsiella pneumoniae</i> – the pneumonia
+                <i lang="la">Klebsiella pneumoniae</i> – the pneumonia
                 bacterium. <br />- Collaboration in the exchange of students and
                 staff.
               </li>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Pokojowa Okupacja Studencka Uniwersytetu Wrocławskiego</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Opór jest najgłębszą formą miłości</q></p>
@@ -63,7 +63,7 @@
       <article>
         <h3><time datetime="2024-09-05">05.09.2024</time>, dzień 95</h3>
         <section>
-          <p>Lekcja arabskiego – piosenki „Wea'ayouneha”, „Ya Zarif Altul” (<span lang="ara">و عيونها٫ يا ظريف الطول</span>)</p>
+          <p>Lekcja arabskiego – piosenki „Wea'ayouneha”, „Ya Zarif Altul” (<span lang="ar-apc" dir="rtl">و عيونها٫ يا ظريف الطول</span>)</p>
           <p>Na kolację zjadłyśmy pyszną szakszukę.</p>
         </section>
       </article>
@@ -3393,7 +3393,7 @@
         <br />Sale: 2, 4, 9, 29 <br />ul. Szewska 50/51 <br />50-139 Wrocław
       </address>
       <aside>
-        <p lang="ara">فلسطين الحرة</p>
+        <p lang="ar-apc" dir="rtl">فلسطين الحرة</p>
       </aside>
     </footer>
   </body>

--- a/index.html
+++ b/index.html
@@ -380,7 +380,7 @@
                 <li>
                   w zakresie wdrożenia skutecznej kombinacji medykamentów w celu
                   ulepszenia terapii przeciwko
-                  <i lang="lat">Klebsiella pneumoniae</i> – pałeczki powodującej
+                  <i lang="la">Klebsiella pneumoniae</i> – pałeczki powodującej
                   zapalenie płuc
                 </li>
                 <li>współpraca w zakresie wymiany studentów i pracowników.</li>
@@ -401,7 +401,7 @@
               <li>
                 W zakresie wdrożenia skutecznej kombinacji medykamentów w celu
                 ulepszenia terapii przeciwko
-                <i lang="lat">Klebsiella pneumoniae</i> – pałeczki powodującej
+                <i lang="la">Klebsiella pneumoniae</i> – pałeczki powodującej
                 zapalenie płuc
                 <ul>
                   <li>Projekt prowadzony w ramach projektu KLEOPATRA;</li>

--- a/pages/en_nav.html
+++ b/pages/en_nav.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Peaceful Student Encampment of the University of Wrocław</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Resistance is the deepest form of love</q></p>
@@ -56,7 +56,7 @@
         <span lang="pl">Wrocław</span>
       </address>
       <aside>
-        <p><span lang="ara">فلسطين الحرة</span></p>
+        <p><span lang="ar-apc" dir="rtl">فلسطين الحرة</span></p>
       </aside>
     </footer>
   </body>

--- a/pages/pl_demands.html
+++ b/pages/pl_demands.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Pokojowa Okupacja Studencka Uniwersytetu Wrocławskiego</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Opór jest najgłębszą formą miłości</q></p>
@@ -122,7 +122,7 @@
         <br />Sale: 2, 4, 9, 29 <br />ul. Szewska 50/51 <br />50-139 Wrocław
       </address>
       <aside>
-        <p lang="ara">فلسطين الحرة</p>
+        <p lang="ar-apc" dir="rtl">فلسطين الحرة</p>
       </aside>
     </footer>
   </body>

--- a/pages/pl_events.html
+++ b/pages/pl_events.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Pokojowa Okupacja Studencka Uniwersytetu Wrocławskiego</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Opór jest najgłębszą formą miłości</q></p>
@@ -228,7 +228,7 @@
         <br />Sale: 2, 4, 9, 29 <br />ul. Szewska 50/51 <br />50-139 Wrocław
       </address>
       <aside>
-        <p lang="ara">فلسطين الحرة</p>
+        <p lang="ar-apc" dir="rtl">فلسطين الحرة</p>
       </aside>
     </footer>
   </body>

--- a/pages/pl_gallery.html
+++ b/pages/pl_gallery.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Pokojowa Okupacja Studencka Uniwersytetu Wrocławskiego</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Opór jest najgłębszą formą miłości</q></p>
@@ -107,7 +107,7 @@
         <br />Sale: 2, 4, 9, 29 <br />ul. Szewska 50/51 <br />50-139 Wrocław
       </address>
       <aside>
-        <p lang="ara">فلسطين الحرة</p>
+        <p lang="ar-apc" dir="rtl">فلسطين الحرة</p>
       </aside>
     </footer>
   </body>

--- a/pages/pl_links.html
+++ b/pages/pl_links.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Pokojowa Okupacja Studencka Uniwersytetu Wrocławskiego</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Opór jest najgłębszą formą miłości</q></p>
@@ -267,7 +267,7 @@
         <br />Sale: 2, 4, 9, 29 <br />ul. Szewska 50/51 <br />50-139 Wrocław
       </address>
       <aside>
-        <p lang="ara">فلسطين الحرة</p>
+        <p lang="ar-apc" dir="rtl">فلسطين الحرة</p>
       </aside>
     </footer>
   </body>

--- a/pages/pl_media.html
+++ b/pages/pl_media.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Pokojowa Okupacja Studencka Uniwersytetu Wrocławskiego</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Opór jest najgłębszą formą miłości</q></p>
@@ -405,7 +405,7 @@
         <br />Sale: 2, 4, 9, 29 <br />ul. Szewska 50/51 <br />50-139 Wrocław
       </address>
       <aside>
-        <p lang="ara">فلسطين الحرة</p>
+        <p lang="ar-apc" dir="rtl">فلسطين الحرة</p>
       </aside>
     </footer>
   </body>

--- a/pages/pl_nav.html
+++ b/pages/pl_nav.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Pokojowa Okupacja Studencka Uniwersytetu Wrocławskiego</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Opór jest najgłębszą formą miłości</q></p>
@@ -58,7 +58,7 @@
         <br />Sale: 2, 4, 9, 29 <br />ul. Szewska 50/51 <br />50-139 Wrocław
       </address>
       <aside>
-        <p lang="ara">فلسطين الحرة</p>
+        <p lang="ar-apc" dir="rtl">فلسطين الحرة</p>
       </aside>
     </footer>
   </body>

--- a/pages/pl_public.html
+++ b/pages/pl_public.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Pokojowa Okupacja Studencka Uniwersytetu Wrocławskiego</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Opór jest najgłębszą formą miłości</q></p>
@@ -151,7 +151,7 @@
         <br />Sale: 2, 4, 9, 29 <br />ul. Szewska 50/51 <br />50-139 Wrocław
       </address>
       <aside>
-        <p lang="ara">فلسطين الحرة</p>
+        <p lang="ar-apc" dir="rtl">فلسطين الحرة</p>
       </aside>
     </footer>
   </body>

--- a/pages/pl_publish.html
+++ b/pages/pl_publish.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Pokojowa Okupacja Studencka Uniwersytetu Wrocławskiego</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Opór jest najgłębszą formą miłości</q></p>
@@ -1072,7 +1072,7 @@
         <br />Sale: 2, 4, 9, 29 <br />ul. Szewska 50/51 <br />50-139 Wrocław
       </address>
       <aside>
-        <p lang="ara">فلسطين الحرة</p>
+        <p lang="ar-apc" dir="rtl">فلسطين الحرة</p>
       </aside>
     </footer>
   </body>

--- a/pages/pl_support.html
+++ b/pages/pl_support.html
@@ -25,7 +25,7 @@
         <img src="../img/conference.jpg" alt="konferencja" />
         <h1>🇵🇸 Pokojowa Okupacja Studencka Uniwersytetu Wrocławskiego</h1>
         <p>
-          <q lang="ara">المقاومة أعمق أنواع الحب</q>
+          <q lang="ar-apc" dir="rtl">المقاومة أعمق أنواع الحب</q>
         </p>
         <aside>
           <p><q>Opór jest najgłębszą formą miłości</q></p>
@@ -174,7 +174,7 @@
         <br />Sale: 2, 4, 9, 29 <br />ul. Szewska 50/51 <br />50-139 Wrocław
       </address>
       <aside>
-        <p lang="ara">فلسطين الحرة</p>
+        <p lang="ar-apc" dir="rtl">فلسطين الحرة</p>
       </aside>
     </footer>
   </body>


### PR DESCRIPTION
Kod "ara" podświetlał się w Lighthouse jako błędny. Poprawiłem go na "ar-apc" ("ar" to ogólnie arabski jako grupa języków, "apc" to kod dialektów syryjsko-palestyńskich. Nie wiem w sumie czy wszędzie są to kawałki po palestyńskiemu...

Druga rzecz to dodanie kierunku czytania tekstu — czasami trochę to zmienia formatowanie albo przenoszenie tekstu z wiersza na wiersz tak żeby to bardziej było logiczne w tym języku.

Informacje o atrybucie lang:
* https://dequeuniversity.com/rules/axe/4.9/valid-lang
* https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1
* [wyszukiwarka kodów](https://iso639-3.sil.org/code_tables/639/data) (dialekty palestyńsko-syryjskie zaznaczone jako "[Levantine Arabic](https://en.wikipedia.org/wiki/Levantine_Arabic)")