### PR TITLE
a11y: Apply 5:1 contrast ratio to links

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -35,7 +35,7 @@ h4 {
 }
 
 a {
-  color: #79c;
+  color: #465c7c;
 }
 
 dl,


### PR DESCRIPTION
Według standardu WCAG 2.1 AA, kontrast pomiędzy kolorem tła a tekstem (małym, < 17pt) ma być 5:1. Wcześniej, wszystkie linki miały 2.cośtam:1 co powoduje złą czytelność. Ten kolor co dodałem to po prostu ciemniejszy wariant byłego, wygenerowany przez Adobe Color: https://color.adobe.com/create/color-contrast-analyzer

More info:
* https://dequeuniversity.com/rules/axe/4.9/color-contrast