### PR TITLE
a11y: Fix ordered lists

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -67,3 +67,7 @@ hr {
 article img {
   width: 50%;
 }
+
+ol.references {
+  list-style-type: none;
+}

--- a/en_index.html
+++ b/en_index.html
@@ -641,116 +641,158 @@
           </blockquote>
           <section>
             <h4>References</h4>
-            <ol>
-              <p>
-                [<a id="d75-footnote-1" href="#d75-footnote-ref-1">1</a>]:
-                <a href="https://www.jpiamr.eu/projects/kleopatra/"
-                  >Kleopatra</a
-                >
-                Program –
-                <span lang="en"
-                  >Joint Programming Initiative on Antimicrobial
-                  Resistance</span
-                >
-                (Accessed <time datetime="2024-08-15">August 15, 2024</time>.)
-              </p>
-              <p>
-                [<a id="d75-footnote-2" href="#d75-footnote-ref-2">2</a>]: B.
-                Morris, B. Z. Kedar.
-                <q lang="en"
-                  >Cast thy bread. Israeli biological warfare during the 1948
-                  War.</q
-                >
-                <i lang="en">Middle Eastern Studies</i> 59 (5) 2023, pp. 752-776
-              </p>
-              <p>
-                [<a id="d75-footnote-3" href="#d75-footnote-ref-3">3</a>]: M.
-                Wind. Towers of Ivory and Steel. How Israeli Universities Deny
-                Palestinian Freedom. London, New York 2024, pp. 23-38
-              </p>
-              <p>
-                [<a id="d75-footnote-4" href="#d75-footnote-ref-4">4</a>]:
-                <i>Ibid</i>, pp. 48-56
-              </p>
-              <p>
-                [<a id="d75-footnote-5" href="#d75-footnote-ref-5">5</a>]:
-                <i>Ibid</i>, p. 45
-              </p>
-              <p>
-                [<a id="d75-footnote-6" href="#d75-footnote-ref-6">6</a>]:
-                <i>Ibid</i>, pp. 45-46
-              </p>
-              <p>
-                [<a id="d75-footnote-7" href="#d75-footnote-ref-7">7</a>]:
-                <i>Ibid</i>, pp. 66-68
-              </p>
-              <p>
-                [<a id="d75-footnote-8" href="#d75-footnote-ref-8">8</a>]:
-                <i>Ibid</i>, pp. 118, 136, 146
-              </p>
-              <p>
-                [<a id="d75-footnote-9" href="#d75-footnote-ref-9">9</a>]:
-                Project
-                <a href="https://www.eradicate-project.eu/projects/"
-                  >eRaDicate</a
-                >. (Accessed <time datetime="2024-08-15">August 15, 2024</time>)
-              </p>
-              <p>
-                [<a id="d75-footnote-10" href="#d75-footnote-ref-10">10</a>]: M.
-                Wind. Towers of Ivory and Steel. How Israeli Universities Deny
-                Palestinian Freedom. London, New York 2024, pp. 77-81
-              </p>
-              <p>
-                [<a id="d75-footnote-11" href="#d75-footnote-ref-11">11</a>]:
-                <i>Ibid</i>, p. 104
-              </p>
-              <p>
-                [<a id="d75-footnote-12" href="#d75-footnote-ref-12">12</a>]:
-                <i>Ibid</i>, pp. 94-100
-              </p>
-              <p>
-                [<a id="d75-footnote-13" href="#d75-footnote-ref-13">13</a>]:
-                <i>Ibid</i>, p. 115
-              </p>
-              <p>
-                [<a id="d75-footnote-14" href="#d75-footnote-ref-14">14</a>]:
-                <i>Ibid</i>, pp. 149-154
-              </p>
-              <p>
-                [<a id="d75-footnote-15" href="#d75-footnote-ref-15">15</a>]:
-                <i>Ibid</i>, pp. 37-39
-              </p>
-              <p>
-                [<a id="d75-footnote-16" href="#d75-footnote-ref-16">16</a>]:
-                <i>Ibid</i>.
-              </p>
-              <p>
-                [<a id="d75-footnote-17" href="#d75-footnote-ref-17">17</a>]:
-                Kasher, Asa and Amos Yadlin,
-                <q>Military ethics of fighting terror: An Israeli perspective</q
-                >. <i>Journal of Military Ethics</i>, 4(1), 3–32, 2005.
-              </p>
-              <p>
-                [<a id="d75-footnote-18" href="#d75-footnote-ref-18">18</a>]: M.
-                Wind. Towers of Ivory and Steel. How Israeli Universities Deny
-                Palestinian Freedom. London, New York 2024, s. 3
-              </p>
-              <p>
-                [<a id="d75-footnote-19" href="#d75-footnote-ref-19">19</a>]:
-                <i>Ibid</i>, p. 102
-              </p>
-              <p>
-                [<a id="d75-footnote-20" href="#d75-footnote-ref-20">20</a>]:
-                <i>Ibid</i>, pp. 37-38
-              </p>
-              <p>
-                [<a id="d75-footnote-21" href="#d75-footnote-ref-21">21</a>]:
-                <a
-                  href="https://international.uni.wroc.pl/pracownicy-uwr/erasmus-dydaktyka/erasmus-kraje-partnerskie"
-                  >Erasmus+</a
-                >
-                Program at UWr.
-              </p>
+            <ol class="references">
+              <li>
+                <p>
+                  [<a id="d75-footnote-1" href="#d75-footnote-ref-1">1</a>]:
+                  <a href="https://www.jpiamr.eu/projects/kleopatra/"
+                    >Kleopatra</a
+                  >
+                  Program –
+                  <span lang="en"
+                    >Joint Programming Initiative on Antimicrobial
+                    Resistance</span
+                  >
+                  (Accessed <time datetime="2024-08-15">August 15, 2024</time>.)
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-2" href="#d75-footnote-ref-2">2</a>]: B.
+                  Morris, B. Z. Kedar.
+                  <q lang="en"
+                    >Cast thy bread. Israeli biological warfare during the 1948
+                    War.</q
+                  >
+                  <i lang="en">Middle Eastern Studies</i> 59 (5) 2023, pp. 752-776
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-3" href="#d75-footnote-ref-3">3</a>]: M.
+                  Wind. Towers of Ivory and Steel. How Israeli Universities Deny
+                  Palestinian Freedom. London, New York 2024, pp. 23-38
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-4" href="#d75-footnote-ref-4">4</a>]:
+                  <i>Ibid</i>, pp. 48-56
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-5" href="#d75-footnote-ref-5">5</a>]:
+                  <i>Ibid</i>, p. 45
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-6" href="#d75-footnote-ref-6">6</a>]:
+                  <i>Ibid</i>, pp. 45-46
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-7" href="#d75-footnote-ref-7">7</a>]:
+                  <i>Ibid</i>, pp. 66-68
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-8" href="#d75-footnote-ref-8">8</a>]:
+                  <i>Ibid</i>, pp. 118, 136, 146
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-9" href="#d75-footnote-ref-9">9</a>]:
+                  Project
+                  <a href="https://www.eradicate-project.eu/projects/"
+                    >eRaDicate</a
+                  >. (Accessed <time datetime="2024-08-15">August 15, 2024</time>)
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-10" href="#d75-footnote-ref-10">10</a>]: M.
+                  Wind. Towers of Ivory and Steel. How Israeli Universities Deny
+                  Palestinian Freedom. London, New York 2024, pp. 77-81
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-11" href="#d75-footnote-ref-11">11</a>]:
+                  <i>Ibid</i>, p. 104
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-12" href="#d75-footnote-ref-12">12</a>]:
+                  <i>Ibid</i>, pp. 94-100
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-13" href="#d75-footnote-ref-13">13</a>]:
+                  <i>Ibid</i>, p. 115
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-14" href="#d75-footnote-ref-14">14</a>]:
+                  <i>Ibid</i>, pp. 149-154
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-15" href="#d75-footnote-ref-15">15</a>]:
+                  <i>Ibid</i>, pp. 37-39
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-16" href="#d75-footnote-ref-16">16</a>]:
+                  <i>Ibid</i>.
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-17" href="#d75-footnote-ref-17">17</a>]:
+                  Kasher, Asa and Amos Yadlin,
+                  <q>Military ethics of fighting terror: An Israeli perspective</q
+                  >. <i>Journal of Military Ethics</i>, 4(1), 3–32, 2005.
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-18" href="#d75-footnote-ref-18">18</a>]: M.
+                  Wind. Towers of Ivory and Steel. How Israeli Universities Deny
+                  Palestinian Freedom. London, New York 2024, s. 3
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-19" href="#d75-footnote-ref-19">19</a>]:
+                  <i>Ibid</i>, p. 102
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-20" href="#d75-footnote-ref-20">20</a>]:
+                  <i>Ibid</i>, pp. 37-38
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-21" href="#d75-footnote-ref-21">21</a>]:
+                  <a
+                    href="https://international.uni.wroc.pl/pracownicy-uwr/erasmus-dydaktyka/erasmus-kraje-partnerskie"
+                    >Erasmus+</a
+                  >
+                  Program at UWr.
+                </p>
+              </li>
             </ol>
           </section>
         </section>

--- a/index.html
+++ b/index.html
@@ -887,118 +887,160 @@
           </blockquote>
           <section>
             <h4>Przypisy</h4>
-            <ol>
-              <p>
-                [<a id="d75-footnote-1" href="#d75-footnote-ref-1">1</a>]:
-                Program
-                <a href="https://www.jpiamr.eu/projects/kleopatra/"
-                  >Kleopatra</a
-                >
-                –
-                <span lang="en"
-                  >Joint Programming Initiative on Antimicrobial
-                  Resistance</span
-                >
-                (Dostęp <time datetime="2024-08-15">15.08.2024</time>)
-              </p>
-              <p>
-                [<a id="d75-footnote-2" href="#d75-footnote-ref-2">2</a>]: B.
-                Morris, B. Z. Kedar.
-                <q lang="en"
-                  >Cast thy bread. Israeli biological warfare during the 1948
-                  War.</q
-                >
-                <i lang="en">Middle Eastern Studies</i> 59 (5) 2023, s. 752-776
-              </p>
-              <p>
-                [<a id="d75-footnote-3" href="#d75-footnote-ref-3">3</a>]: M.
-                Wind. Towers of Ivory and Steel. How Israeli Universities Deny
-                Palestinian Freedom. London, New York 2024, s. 23-38
-              </p>
-              <p>
-                [<a id="d75-footnote-4" href="#d75-footnote-ref-4">4</a>]:
-                <i>Ibidem</i>, s. 48-56
-              </p>
-              <p>
-                [<a id="d75-footnote-5" href="#d75-footnote-ref-5">5</a>]:
-                <i>Ibidem</i>, s. 45
-              </p>
-              <p>
-                [<a id="d75-footnote-6" href="#d75-footnote-ref-6">6</a>]:
-                <i>Ibidem</i>, s. 45-46
-              </p>
-              <p>
-                [<a id="d75-footnote-7" href="#d75-footnote-ref-7">7</a>]:
-                <i>Ibidem</i>, s. 66-68
-              </p>
-              <p>
-                [<a id="d75-footnote-8" href="#d75-footnote-ref-8">8</a>]:
-                <i>Ibidem</i>, s. 118, 136, 146
-              </p>
-              <p>
-                [<a id="d75-footnote-9" href="#d75-footnote-ref-9">9</a>]:
-                Project
-                <a href="https://www.eradicate-project.eu/projects/"
-                  >eRaDicate</a
-                >. (Dostęp <time datetime="2024-08-15">15.08.2024</time>)
-              </p>
-              <p>
-                [<a id="d75-footnote-10" href="#d75-footnote-ref-10">10</a>]: M.
-                Wind. Towers of Ivory and Steel. How Israeli Universities Deny
-                Palestinian Freedom. London, New York 2024, s. 77-81
-              </p>
-              <p>
-                [<a id="d75-footnote-11" href="#d75-footnote-ref-11">11</a>]:
-                <i>Ibidem</i>, s. 104
-              </p>
-              <p>
-                [<a id="d75-footnote-12" href="#d75-footnote-ref-12">12</a>]:
-                <i>Ibidem</i>, s. 94-100
-              </p>
-              <p>
-                [<a id="d75-footnote-13" href="#d75-footnote-ref-13">13</a>]:
-                <i>Ibidem</i>, s. 115
-              </p>
-              <p>
-                [<a id="d75-footnote-14" href="#d75-footnote-ref-14">14</a>]:
-                <i>Ibidem</i>, s. 149-154
-              </p>
-              <p>
-                [<a id="d75-footnote-15" href="#d75-footnote-ref-15">15</a>]:
-                <i>Ibidem</i>, s. 37-39
-              </p>
-              <p>
-                [<a id="d75-footnote-16" href="#d75-footnote-ref-16">16</a>]:
-                <i>Ibidem</i>.
-              </p>
-              <p>
-                [<a id="d75-footnote-17" href="#d75-footnote-ref-17">17</a>]:
-                Kasher, Asa and Amos Yadlin,
-                <q>Military ethics of fighting terror: An Israeli perspective</q
-                >. <i>Journal of Military Ethics</i>, 4(1), 3–32, 2005.
-              </p>
-              <p>
-                [<a id="d75-footnote-18" href="#d75-footnote-ref-18">18</a>]: M.
-                Wind. Towers of Ivory and Steel. How Israeli Universities Deny
-                Palestinian Freedom. London, New York 2024, s. 3
-              </p>
-              <p>
-                [<a id="d75-footnote-19" href="#d75-footnote-ref-19">19</a>]:
-                <i>Ibidem</i>, s. 102
-              </p>
-              <p>
-                [<a id="d75-footnote-20" href="#d75-footnote-ref-20">20</a>]:
-                <i>Ibidem</i>, s. 37-38
-              </p>
-              <p>
-                [<a id="d75-footnote-21" href="#d75-footnote-ref-21">21</a>]:
-                Program
-                <a
-                  href="https://international.uni.wroc.pl/pracownicy-uwr/erasmus-dydaktyka/erasmus-kraje-partnerskie"
-                  >Erasmus+</a
-                >
-                na UWr.
-              </p>
+            <ol class="references">
+              <li>
+                <p>
+                  [<a id="d75-footnote-1" href="#d75-footnote-ref-1">1</a>]:
+                  Program
+                  <a href="https://www.jpiamr.eu/projects/kleopatra/"
+                    >Kleopatra</a
+                  >
+                  –
+                  <span lang="en"
+                    >Joint Programming Initiative on Antimicrobial
+                    Resistance</span
+                  >
+                  (Dostęp <time datetime="2024-08-15">15.08.2024</time>)
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-2" href="#d75-footnote-ref-2">2</a>]: B.
+                  Morris, B. Z. Kedar.
+                  <q lang="en"
+                    >Cast thy bread. Israeli biological warfare during the 1948
+                    War.</q
+                  >
+                  <i lang="en">Middle Eastern Studies</i> 59 (5) 2023, s. 752-776
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-3" href="#d75-footnote-ref-3">3</a>]: M.
+                  Wind. Towers of Ivory and Steel. How Israeli Universities Deny
+                  Palestinian Freedom. London, New York 2024, s. 23-38
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-4" href="#d75-footnote-ref-4">4</a>]:
+                  <i>Ibidem</i>, s. 48-56
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-5" href="#d75-footnote-ref-5">5</a>]:
+                  <i>Ibidem</i>, s. 45
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-6" href="#d75-footnote-ref-6">6</a>]:
+                  <i>Ibidem</i>, s. 45-46
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-7" href="#d75-footnote-ref-7">7</a>]:
+                  <i>Ibidem</i>, s. 66-68
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-8" href="#d75-footnote-ref-8">8</a>]:
+                  <i>Ibidem</i>, s. 118, 136, 146
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-9" href="#d75-footnote-ref-9">9</a>]:
+                  Project
+                  <a href="https://www.eradicate-project.eu/projects/"
+                    >eRaDicate</a
+                  >. (Dostęp <time datetime="2024-08-15">15.08.2024</time>)
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-10" href="#d75-footnote-ref-10">10</a>]: M.
+                  Wind. Towers of Ivory and Steel. How Israeli Universities Deny
+                  Palestinian Freedom. London, New York 2024, s. 77-81
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-11" href="#d75-footnote-ref-11">11</a>]:
+                  <i>Ibidem</i>, s. 104
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-12" href="#d75-footnote-ref-12">12</a>]:
+                  <i>Ibidem</i>, s. 94-100
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-13" href="#d75-footnote-ref-13">13</a>]:
+                  <i>Ibidem</i>, s. 115
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-14" href="#d75-footnote-ref-14">14</a>]:
+                  <i>Ibidem</i>, s. 149-154
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-15" href="#d75-footnote-ref-15">15</a>]:
+                  <i>Ibidem</i>, s. 37-39
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-16" href="#d75-footnote-ref-16">16</a>]:
+                  <i>Ibidem</i>.
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-17" href="#d75-footnote-ref-17">17</a>]:
+                  Kasher, Asa and Amos Yadlin,
+                  <q>Military ethics of fighting terror: An Israeli perspective</q
+                  >. <i>Journal of Military Ethics</i>, 4(1), 3–32, 2005.
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-18" href="#d75-footnote-ref-18">18</a>]: M.
+                  Wind. Towers of Ivory and Steel. How Israeli Universities Deny
+                  Palestinian Freedom. London, New York 2024, s. 3
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-19" href="#d75-footnote-ref-19">19</a>]:
+                  <i>Ibidem</i>, s. 102
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-20" href="#d75-footnote-ref-20">20</a>]:
+                  <i>Ibidem</i>, s. 37-38
+                </p>
+              </li>
+              <li>
+                <p>
+                  [<a id="d75-footnote-21" href="#d75-footnote-ref-21">21</a>]:
+                  Program
+                  <a
+                    href="https://international.uni.wroc.pl/pracownicy-uwr/erasmus-dydaktyka/erasmus-kraje-partnerskie"
+                    >Erasmus+</a
+                  >
+                  na UWr.
+                </p>
+              </li>
             </ol>
           </section>
         </section>


### PR DESCRIPTION
Element `<ol>` musi mieć "dzieci" `<li>`. Jeżeli się nie chce mieć numerków, ma to być rozwiązane przez CSS.

Info:
* https://dequeuniversity.com/rules/axe/4.9/list
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol#usage_notes