### PR TITLE
a11y: Add an example of good alt text

### DIFF
--- a/pages/pl_gallery.html
+++ b/pages/pl_gallery.html
@@ -64,7 +64,7 @@
         >).
       </p>
 
-      <img src="../img/conference.jpg" />
+      <img src="../img/conference.jpg" alt="Grupa osób z okupacji z banerami przy wejściu do patio Uniwersytetu Wrocławskiego na Szewskiej 50/51. Z okna zwisa duża flaga Palestyny." />
 
       <p>
         Konferencja prasowa z <time datetime="2024-08-16">16.08.2024</time>.


### PR DESCRIPTION
Koniecznie trzeba dodać alt teksty do wszystkich obrazków Osoby z wadami wzroku liczą na obecność tego opisu by móc zrozumieć o co chodzi na obrazkach.

Info:
* https://accessibility.huit.harvard.edu/describe-content-images